### PR TITLE
Add universe repo and update repos before install

### DIFF
--- a/.github/workflows/nightly_pypi.yml
+++ b/.github/workflows/nightly_pypi.yml
@@ -17,6 +17,9 @@ jobs:
         python-version: 3.7
     - name : Install Prerequisites
       run : |
+        sudo apt-get install software-properties-common
+        sudo apt-add-repository universe
+        sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
         sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -16,6 +16,9 @@ jobs:
         python-version: 3.7
     - name : Install Prerequisites
       run : |
+        sudo apt-get install software-properties-common
+        sudo apt-add-repository universe
+        sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
         sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y


### PR DESCRIPTION
Fixes the following error in the release CI:

```bash
  sudo apt-get install gcc libpq-dev -y
  sudo apt-get install python-dev  python-pip -y
  sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y
  pip3 install wheel
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.7.10/x64
Reading package lists...
Building dependency tree...
Reading state information...
gcc is already the newest version (4:9.3.0-1ubuntu2).
gcc set to manually installed.
libpq-dev is already the newest version (13.2-1.pgdg20.04+1).
0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python-pip
Error: Process completed with exit code 100.
```