### PR TITLE
Remove deprecated python-pip unavailable on ubuntu-20.04

### DIFF
--- a/.github/workflows/nightly_pypi.yml
+++ b/.github/workflows/nightly_pypi.yml
@@ -21,7 +21,6 @@ jobs:
         sudo apt-add-repository universe
         sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
-        sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y
         pip3 install wheel
     - name : Update Version numbers

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -20,7 +20,6 @@ jobs:
         sudo apt-add-repository universe
         sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
-        sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y
         pip3 install wheel
     - name: Build sdist and bdist_wheel


### PR DESCRIPTION
> Pip for Python 2 is not included in the Ubuntu 20.04 repositories.
> You need to install pip for Python 2 using the get-pip.py script.

from - https://stackoverflow.com/a/62724749/5096749